### PR TITLE
Fix syntax issues in ASN.1 module.

### DIFF
--- a/draft-ounsworth-pq-composite-keys.mkd
+++ b/draft-ounsworth-pq-composite-keys.mkd
@@ -784,14 +784,13 @@ SEQUENCE {
 <CODE STARTS>
 
 Composite-Keys-2022
-  { TBD }
 
 DEFINITIONS IMPLICIT TAGS ::= BEGIN
 
 EXPORTS ALL;
 
 IMPORTS
-  PUBLIC-KEY, SIGNATURE-ALGORITHM
+  PUBLIC-KEY, SIGNATURE-ALGORITHM, ParamOptions
     FROM AlgorithmInformation-2009  -- RFC 5912 [X509ASN1]
       { iso(1) identified-organization(3) dod(6) internet(1)
         security(5) mechanisms(5) pkix(7) id-mod(0)
@@ -812,21 +811,24 @@ IMPORTS
 --
 -- Object Identifiers
 --
+ 
+der OBJECT IDENTIFIER ::=
+  {joint-iso-itu-t asn1(1) ber-derived(2) distinguished-encoding(1)}
 
 -- To be replaced by IANA
 id-composite-key OBJECT IDENTIFIER ::= {
-  iso(1) identified-organization(3) dod(6) internet(1) private(4) 
-  enterprise(1) OpenCA(18227) algorithms(2) id-pk-compositeCrypto(1) }
+  iso(1) identified-organization(3) dod(6) internet(1) private(4)
+  enterprise(1) openCA(18227) algorithms(2) id-pk-compositeCrypto(1) }
 
 --
 -- Public Key
 --
 
 pk-Composite PUBLIC-KEY ::= {
-    id id-composite-key,
-    KeyValue CompositePublicKey,
-    Params CompositeParams ARE OPTIONAL,
-    PrivateKey CompositePrivateKey,
+    IDENTIFIER id-composite-key
+    KEY CompositePublicKey
+    PARAMS TYPE CompositeParams ARE optional
+    PRIVATE-KEY CompositePrivateKey
 }
 
 CompositePublicKey ::= SEQUENCE SIZE (2..MAX) OF SubjectPublicKeyInfo
@@ -841,7 +843,7 @@ CompositePrivateKey ::= SEQUENCE SIZE (2..MAX) OF OneAsymmetricKey
 -- pk-explicitComposite - Composite public key information object
 
 pk-explicitComposite{OBJECT IDENTIFIER:id, PUBLIC-KEY:firstPublicKey,
-  FirstPublicKeyType, PUBLIC-KEY:secondPublicKey, SecondPublicKeyType} 
+  FirstPublicKeyType, PUBLIC-KEY:secondPublicKey, SecondPublicKeyType}
   PUBLIC-KEY ::= {
     IDENTIFIER id
     KEY ExplicitCompositePublicKey{firstPublicKey, FirstPublicKeyType,
@@ -849,14 +851,14 @@ pk-explicitComposite{OBJECT IDENTIFIER:id, PUBLIC-KEY:firstPublicKey,
     PARAMS ARE absent
 }
 
-   The following ASN.1 object class then automatically generates the
-   public key structure from the types defined in pk-explicitComposite.
+-- The following ASN.1 object class then automatically generates the
+-- public key structure from the types defined in pk-explicitComposite.
 
--- ExplicitCompositePublicKey - The data structure for a composite 
--- public key sec-composite-pub-keys and SecondPublicKeyType are needed 
+-- ExplicitCompositePublicKey - The data structure for a composite
+-- public key sec-composite-pub-keys and SecondPublicKeyType are needed
 -- because PUBLIC-KEY contains a set of public key types, not a single
 -- type.
--- TODO The parameters should be optional only if they are marked 
+-- TODO The parameters should be optional only if they are marked
 -- optional in the PUBLIC-KEY
 
 


### PR DESCRIPTION
To run ASN.1 syntax checker this commit fixes small typos and adds missing imports. Also fixes pk-composite where some parameters of PUBLIC-KEY class where missing.