### PR TITLE
Rework composite key component ordering text

### DIFF
--- a/draft-ounsworth-pq-composite-keys.mkd
+++ b/draft-ounsworth-pq-composite-keys.mkd
@@ -267,7 +267,7 @@ CompositePublicKey ::= SEQUENCE SIZE (2..MAX) OF SubjectPublicKeyInfo
 {: artwork-name="CompositePublicKey-asn.1-structures"}
 
 
-A composite key MUST contain at least two component public keys.
+A composite key MUST contain at least two component public keys.  When the composite key is used in conjunction with an explicit composite algorithm identifier defined under section {{sec-alg-ids}}, the order of the component keys is determined by that algorithm identifier's definition.  Otherwise, the composite key is considered to be used in conjunction with the algorithm identifier id-composite-key defined in {{sec-generic-composite}}, and no ordering constraint applies.
 
 A CompositePublicKey MUST NOT contain a component public key which itself describes a composite key; i.e. recursive CompositePublicKeys are not allowed.
 
@@ -296,7 +296,7 @@ Each element is a OneAsymmetricKey [RFC5958] object for a component private key.
 
 The parameters field MUST be absent.
 
-A CompositePrivateKey MUST contain at least two component private keys, and they MUST be in the same order as in the corresponding CompositePublicKey.
+A CompositePrivateKey MUST contain at least two component private keys, and the order of the component keys is the same as the order defined in {{sec-composite-pub-keys}} for the components of CompositePublicKey.
 
 EDNOTE: does this also need an explicit version? It would probably reduce attack surface of tricking a client into running the wrong parser and a given piece of data. ... maybe we get that for free if we use the explicit composite OIDs also for private keys?
 
@@ -331,7 +331,7 @@ https://mailarchive.ietf.org/arch/msg/spasm/Gv-ACiOpYZfOM0AJEZUX1jIhVq0/
 
 # Algorithm Identifiers {#sec-alg-ids}
 
-This section defines the algorithm identifier for generic composite, as well as a framework for defining explicit combinations and a list of explicit composite algorithms covering a wide range of use cases. This section is not intended to be exhaustive and other authors may define others so long as they are compatible with the structures and processes defined in this and companion signature and encryption documents.
+This section defines the algorithm identifier for generic composite, as well as a framework for defining explicit combinations and a list of explicit composite algorithms covering a wide range of use cases. This section is not intended to be exhaustive and other authors may define others so long as they are compatible with the structures and processes defined in this and companion signature and encryption documents, including defining the order of the components of the corresponding composite keys.
 
 Some use-cases desire the flexibility for client to use any combination of supported algorithms, while others desire the rigidity of explicitly-specified combinations of algorithms.
 
@@ -341,7 +341,7 @@ Usage guidance: This mode is primarily for prototyping and for use in proprietar
 
 EDNOTE: Does the WG feel strongly that this section should be removed prior to publication by the RFC Editors? IE remove it entirely from the standard? Are there enduring (ie non-prototyping) usecases that benefit from generic composite?
 
-The id-composite-key object identifier is used for identifying a generic composite public key and a generic composite private key. This allows arbitrary combinations of key types to be placed in the CompositePublicKey and CompositePrivateKey structures without needing the combination to be pre-registered or standardized. 
+The id-composite-key object identifier is used for identifying a generic composite public key and a generic composite private key. This allows arbitrary combinations of key types to be placed in the CompositePublicKey and CompositePrivateKey structures without needing the combination to be pre-registered or standardized. No order is defined for the components of CompositePublicKey or CompositePrivateKey structures identified by id-composite-key.
 
 ~~~ asn.1
 id-composite-key OBJECT IDENTIFIER ::= {

--- a/draft-ounsworth-pq-composite-keys.txt
+++ b/draft-ounsworth-pq-composite-keys.txt
@@ -5,10 +5,10 @@
 LAMPS                                                       M. Ounsworth
 Internet-Draft                                                   Entrust
 Intended status: Standards Track                                 M. Pala
-Expires: 25 April 2023                                         CableLabs
+Expires: 12 May 2023                                           CableLabs
                                                             J. Klaussner
                                                             D-Trust GmbH
-                                                         22 October 2022
+                                                         8 November 2022
 
 
        Composite Public and Private Keys For Use In Internet PKI
@@ -53,9 +53,9 @@ Abstract
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                 [Page 1]
+Ounsworth, et al.          Expires 12 May 2023                  [Page 1]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 Status of This Memo
@@ -73,7 +73,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 25 April 2023.
+   This Internet-Draft will expire on 12 May 2023.
 
 Copyright Notice
 
@@ -97,25 +97,25 @@ Table of Contents
    3.  Composite Key Structures  . . . . . . . . . . . . . . . . . .   6
      3.1.  CompositePublicKey  . . . . . . . . . . . . . . . . . . .   6
      3.2.  CompositePrivateKey . . . . . . . . . . . . . . . . . . .   7
-       3.2.1.  Key Usage . . . . . . . . . . . . . . . . . . . . . .   7
+       3.2.1.  Key Usage . . . . . . . . . . . . . . . . . . . . . .   8
      3.3.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   8
    4.  Algorithm Identifiers . . . . . . . . . . . . . . . . . . . .   8
      4.1.  id-composite-key (Generic Composite Keys) . . . . . . . .   9
      4.2.  Explicit Composite Signature Keys . . . . . . . . . . . .  10
        4.2.1.  id-Dilithium3-ECDSA-P256  . . . . . . . . . . . . . .  11
-       4.2.2.  id-Dilithium3-RSA . . . . . . . . . . . . . . . . . .  13
+       4.2.2.  id-Dilithium3-RSA . . . . . . . . . . . . . . . . . .  14
        4.2.3.  id-Falcon512-ECDSA-P256 . . . . . . . . . . . . . . .  16
        4.2.4.  id-Falcon512-Ed25519  . . . . . . . . . . . . . . . .  16
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                 [Page 2]
+Ounsworth, et al.          Expires 12 May 2023                  [Page 2]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
        4.2.5.  id-SPHINCSsha256256frobust-ECDSA-P256 . . . . . . . .  16
-       4.2.6.  id-Dilithium5-Falcon1024-ECDSA-P521 . . . . . . . . .  16
+       4.2.6.  id-Dilithium5-Falcon1024-ECDSA-P521 . . . . . . . . .  17
        4.2.7.  id-Dilithium5-Falcon1024-RSA  . . . . . . . . . . . .  17
      4.3.  Explicit Composite KEM Keys . . . . . . . . . . . . . . .  17
        4.3.1.  id-Kyber512-RSA . . . . . . . . . . . . . . . . . . .  17
@@ -129,9 +129,9 @@ Internet-Draft              PQ Composite Keys               October 2022
    6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
      7.1.  Reuse of keys in a Composite public key . . . . . . . . .  20
-     7.2.  Key mismatch in explicit composite  . . . . . . . . . . .  20
+     7.2.  Key mismatch in explicit composite  . . . . . . . . . . .  21
      7.3.  Policy for Deprecated and Acceptable Algorithms . . . . .  21
-     7.4.  Protection of Private Keys  . . . . . . . . . . . . . . .  21
+     7.4.  Protection of Private Keys  . . . . . . . . . . . . . . .  22
      7.5.  Checking for Compromised Key Reuse  . . . . . . . . . . .  22
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  22
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .  22
@@ -165,9 +165,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                 [Page 3]
+Ounsworth, et al.          Expires 12 May 2023                  [Page 3]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
          o  id-Dilithium3-ECDSA-P256
@@ -221,9 +221,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                 [Page 4]
+Ounsworth, et al.          Expires 12 May 2023                  [Page 4]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    BER: Basic Encoding Rules (BER) as defined in [X.690].
@@ -277,9 +277,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                 [Page 5]
+Ounsworth, et al.          Expires 12 May 2023                  [Page 5]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    This document provides the composite mechanism, which is a specific
@@ -317,10 +317,26 @@ Internet-Draft              PQ Composite Keys               October 2022
    CompositePublicKey ::= SEQUENCE SIZE (2..MAX) OF SubjectPublicKeyInfo
 
    A composite key MUST contain at least two component public keys.
+   When the composite key is used in conjunction with an explicit
+   composite algorithm identifier defined under section Section 4, the
+   order of the component keys is determined by that algorithm
+   identifier's definition.  Otherwise, the composite key is considered
+   to be used in conjunction with the algorithm identifier id-composite-
+   key defined in Section 4.1, and no ordering constraint applies.
 
    A CompositePublicKey MUST NOT contain a component public key which
    itself describes a composite key; i.e. recursive CompositePublicKeys
    are not allowed.
+
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                  [Page 6]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
 
    EDNOTE: unclear that banning recursive composite keys actually
    accomplishes anything other than a general reduction in complexity
@@ -330,13 +346,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    AlgorithmIdentifier OID which identifies the public key type and
    parameters for the public key contained within it.  See Section 4 for
    specific algorithms defined in this document.
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                 [Page 6]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    Each element of a CompositePublicKey is a SubjectPublicKeyInfo object
    encoding a component public key.  When the CompositePublicKey must be
@@ -369,13 +378,21 @@ Internet-Draft              PQ Composite Keys               October 2022
    The parameters field MUST be absent.
 
    A CompositePrivateKey MUST contain at least two component private
-   keys, and they MUST be in the same order as in the corresponding
-   CompositePublicKey.
+   keys, and the order of the component keys is the same as the order
+   defined in Section 3.1 for the components of CompositePublicKey.
 
    EDNOTE: does this also need an explicit version?  It would probably
    reduce attack surface of tricking a client into running the wrong
    parser and a given piece of data. ... maybe we get that for free if
    we use the explicit composite OIDs also for private keys?
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                  [Page 7]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
 
 3.2.1.  Key Usage
 
@@ -386,14 +403,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    KeyUsage of digitalSignature, then all component keys MUST be capable
    of producing digital signatures.  The composite mechanism MUST NOT be
    used to implement mixed-usage keys, for example, where a
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                 [Page 7]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
-
    digitalSignature and a keyEncipherment key are combined together into
    a single composite key.
 
@@ -433,22 +442,20 @@ Internet-Draft              PQ Composite Keys               October 2022
    This section is not intended to be exhaustive and other authors may
    define others so long as they are compatible with the structures and
    processes defined in this and companion signature and encryption
-   documents.
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                  [Page 8]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
+   documents, including defining the order of the components of the
+   corresponding composite keys.
 
    Some use-cases desire the flexibility for client to use any
    combination of supported algorithms, while others desire the rigidity
    of explicitly-specified combinations of algorithms.
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                 [Page 8]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
 4.1.  id-composite-key (Generic Composite Keys)
 
@@ -467,7 +474,9 @@ Internet-Draft              PQ Composite Keys               October 2022
    generic composite public key and a generic composite private key.
    This allows arbitrary combinations of key types to be placed in the
    CompositePublicKey and CompositePrivateKey structures without needing
-   the combination to be pre-registered or standardized.
+   the combination to be pre-registered or standardized.  No order is
+   defined for the components of CompositePublicKey or
+   CompositePrivateKey structures identified by id-composite-key.
 
    id-composite-key OBJECT IDENTIFIER ::= {
        joint-iso-itu-t(2) country(16) us(840) organization(1) entrust(114027)
@@ -488,6 +497,15 @@ Internet-Draft              PQ Composite Keys               October 2022
        PrivateKey CompositePrivateKey
    }
 
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                  [Page 9]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    The motivation for this variant is primarily for prototyping work
    prior to the standardization of algorithm identifiers for explicit
    combinations of algorithms.  However, the authors envision that this
@@ -497,14 +515,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    large number of keys will be used at a time and it is therefore
    prohibitive to define algorithm identifiers for every combination of
    pairs, triples, quadruples, etc of algorithms.
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                 [Page 9]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
 4.2.  Explicit Composite Signature Keys
 
@@ -538,6 +548,20 @@ Internet-Draft              PQ Composite Keys               October 2022
    registered to represent a specific combination of component public
    key types.  See Appendix B for examples.
 
+
+
+
+
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 10]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    The SubjectPublicKeyInfo.algorithm for each component key is
    redundant information which MUST match -- and can be inferred from --
    the specification of the explicit algorithm.  It has been left here
@@ -554,14 +578,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    and then proceed to parse the SubjectPublicKeyInfo.subjectPublicKey.
    This is to reduce the attack surface associated with parsing the
    public key data of an unexpected key type, or worse; to parse and use
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 10]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
-
    a key which does not match the explicit algorithm definition.
    Similar checks MUST be done when handling the corresponding private
    key.
@@ -595,6 +611,13 @@ Internet-Draft              PQ Composite Keys               October 2022
 
    When used in an AlgorithmIdentifier, parameters SHALL be ABSENT.
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 11]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    The PUBLIC-KEY SHALL be:
 
    pk-Dilithium3-ECDSA-P256 PUBLIC-KEY ::= {
@@ -610,13 +633,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    CompositePrivateKey, or should we define Dilithium3-ECDSA-
    P256-PublicKey and Dilithium3-ECDSA-P256-PrivateKey for each explicit
    type?
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 11]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    Pros of a *-PublicKey for each explicit composite type: 1) the ASN.1
    parser will do some of the heavy-lifting of checking that types match
@@ -650,6 +666,14 @@ Internet-Draft              PQ Composite Keys               October 2022
         subjectPublicKey     BIT STRING(DilithiumPublicKey)
    }
 
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 12]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    where pk-dilithiumTBD and TBDDilithiumPublicKey are defined in
    [I-D.massimo-lamps-pq-sig-certificates].
 
@@ -661,18 +685,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    with future versions of that draft.
 
    The second SubjectPublicKeyInfo SHALL contain:
-
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 12]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    SEQUENCE  {
         algorithm  AlgorithmIdentifier {
@@ -711,6 +723,13 @@ Internet-Draft              PQ Composite Keys               October 2022
      },
    privateKey ECPrivateKey
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 13]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    where ECPrivateKey is defined in [RFC5480].
 
    The publicKey remains OPTIONAL.
@@ -722,13 +741,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    not elliptic curve.
 
    The following object identifier is defined:
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 13]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    id-Dilithium3-RSA OBJECT IDENTIFIER ::= {
      joint-iso-itu-t(2) country(16) us(840) organization(1) entrust(114027)
@@ -759,6 +771,21 @@ Internet-Draft              PQ Composite Keys               October 2022
    (but how much is up for debate..). 2) can further compress the
    encoding by removing the redundant inner component OIDs.
 
+
+
+
+
+
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 14]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    Pros of CompositePublicKey (ie carrying full SPKIs for each
    component): 1) it becomes harder to write abstract code that takes
    advantange of the fact that all composite explicit types have the
@@ -777,14 +804,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    CompositePublicKey ::= SEQUENCE SIZE (2) OF SubjectPublicKeyInfo
 
    The first SubjectPublicKeyInfo (defined in [RFC5280]) SHALL contain:
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 14]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    SEQUENCE  {
         algorithm  AlgorithmIdentifier {
@@ -816,6 +835,13 @@ Internet-Draft              PQ Composite Keys               October 2022
 
    where rsaEncryption and RSAPublicKey are defined in [RFC8017].
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 15]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    The private key encoding is defined in Section 3.2, and for id-
    Dilithium3-ECDSA-P256 SHALL have SIZE (2):
 
@@ -832,15 +858,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    The publicKey remains OPTIONAL.
 
    The second OneAsymmetricKey SHALL contain
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 15]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    privateKeyAlgorithm AlgorithmIdentifier ::= {
        algorithm id-ecPublicKey,
@@ -874,6 +891,13 @@ Internet-Draft              PQ Composite Keys               October 2022
    implementation bugs that comes from coupling with mature ECDSA
    implementations.
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 16]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    TODO: fill in details.
 
 4.2.6.  id-Dilithium5-Falcon1024-ECDSA-P521
@@ -887,16 +911,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    fill in numbers.
 
    TODO: fill in details.
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 16]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
 4.2.7.  id-Dilithium5-Falcon1024-RSA
 
@@ -933,6 +947,13 @@ Internet-Draft              PQ Composite Keys               October 2022
    This section addresses practical issues of how this draft affects
    other protocols and standards.
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 17]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    EDNOTE 10: Possible topics to address:
 
    *  The size of these certs and cert chains.
@@ -942,17 +963,6 @@ Internet-Draft              PQ Composite Keys               October 2022
 
    *  If a cert in the chain is a composite cert then does the whole
       chain need to be of composite Certs?
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 17]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    *  We could also explain that the root CA cert does not have to be of
       the same algorithms.  The root cert SHOULD NOT be transferred in
@@ -984,6 +994,22 @@ Internet-Draft              PQ Composite Keys               October 2022
    specific; that existing systems, as they are deployed today, can
    interoperate with the upgraded systems of the future.
 
+
+
+
+
+
+
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 18]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    These migration and interoperability concerns need to be thought
    about in the context of various types of protocols that make use of
    X.509 and PKIX with relation to public key objects, from online
@@ -994,21 +1020,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    signing [codeSigningBRsv2.8], as well as myriad other standardized
    and proprietary protocols and applications that leverage CMS
    [RFC5652] signed or encrypted structures.
-
-
-
-
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 18]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
 5.2.1.  OR modes
 
@@ -1045,6 +1056,16 @@ Internet-Draft              PQ Composite Keys               October 2022
    [I-D.becker-guthrie-noncomposite-hybrid-auth] and highlights the
    synergy between composite and non-composite hybrid approaches.
 
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 19]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    Equipped with a set of parallel public keys in this way, a client
    would have the flexibility to choose which public key(s) or
    certificate(s) to use in a given cryptographic operation.
@@ -1058,14 +1079,6 @@ Internet-Draft              PQ Composite Keys               October 2022
    [I-D.ounsworth-pq-composite-sigs] as a way to carry the multiple
    signature values generated by a non-composite public mechanism in
    protocols where it is easier to support the composite signature
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 19]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
-
    algorithms than to implement such a mechanism in the protocol itself.
    There is also nothing precluding a composite public key from being
    one of the components used within a non-composite authentication
@@ -1101,6 +1114,14 @@ Internet-Draft              PQ Composite Keys               October 2022
    context and therefore it is RECOMMENDED that component keys in a
    composite key are not to be re-used in other contexts.  In
    particular, the components of a composite key SHOULD NOT also appear
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 20]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    in single-key certificates.  This is particularly relevant for
    protocols that use composite keys in a logical AND mode since the
    appearance of the same component keys in single-key contexts
@@ -1112,15 +1133,6 @@ Internet-Draft              PQ Composite Keys               October 2022
 7.2.  Key mismatch in explicit composite
 
    This security consideration copied from Section 4.2.
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 20]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    Implementations MUST check that that the component
    AlgorithmIdentifier OIDs and parameters match those expected by the
@@ -1157,26 +1169,21 @@ Internet-Draft              PQ Composite Keys               October 2022
    EDNOTE: Max had proposed a CRL mechanism to accomplish this, which
    could be revived if necessary.
 
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 21]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
 7.4.  Protection of Private Keys
 
    Structures described in this document do not protect private keys in
    any way unless combined with a security protocol or encryption
    properties of the objects (if any) where the CompositePrivateKey is
    used.
-
-
-
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 21]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    Protection of the private keys is vital to public key cryptography.
    The consequences of disclosure depend on the purpose of the private
@@ -1214,25 +1221,25 @@ Internet-Draft              PQ Composite Keys               October 2022
               <https://www.ietf.org/archive/id/draft-massimo-lamps-pq-
               sig-certificates-00.txt>.
 
+
+
+
+
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 22]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    [I-D.ounsworth-pq-composite-kem]
               Ounsworth, M. and J. Gray, "Composite KEM For Use In
               Internet PKI", Work in Progress, Internet-Draft, draft-
               ounsworth-pq-composite-kem-00, 11 July 2022,
               <https://www.ietf.org/archive/id/draft-ounsworth-pq-
               composite-kem-00.txt>.
-
-
-
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 22]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    [I-D.ounsworth-pq-composite-sigs]
               Ounsworth, M. and M. Pala, "Composite Signatures For Use
@@ -1276,19 +1283,16 @@ Internet-Draft              PQ Composite Keys               October 2022
               DOI 10.17487/RFC5912, June 2010,
               <https://www.rfc-editor.org/info/rfc5912>.
 
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 23]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    [RFC5914]  Housley, R., Ashmore, S., and C. Wallace, "Trust Anchor
               Format", RFC 5914, DOI 10.17487/RFC5914, June 2010,
               <https://www.rfc-editor.org/info/rfc5914>.
-
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 23]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    [RFC5915]  Turner, S. and D. Brown, "Elliptic Curve Private Key
               Structure", RFC 5915, DOI 10.17487/RFC5915, June 2010,
@@ -1333,18 +1337,19 @@ Internet-Draft              PQ Composite Keys               October 2022
               infrastructure", 2017, <https://link.springer.com/
               chapter/10.1007/978-3-319-59879-6_22>.
 
+
+
+
+
+Ounsworth, et al.          Expires 12 May 2023                 [Page 24]
+
+Internet-Draft              PQ Composite Keys              November 2022
+
+
    [Bleichenbacher1998]
               Bleichenbacher, D., "Chosen ciphertext attacks against
               protocols based on the RSA encryption standard PKCS# 1.",
               1998.
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 24]
-
-Internet-Draft              PQ Composite Keys               October 2022
-
 
    [Castryck2022]
               Castryck, W. and T. Decru, "An efficient key recovery
@@ -1392,14 +1397,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-
-
-
-
-
-Ounsworth, et al.         Expires 25 April 2023                [Page 25]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 25]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    [Mosca2015]
@@ -1453,9 +1453,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 26]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 26]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 Appendix A.  Creating explicit combinations
@@ -1509,9 +1509,9 @@ Appendix A.  Creating explicit combinations
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 27]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 27]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    -- ExplicitCompositePublicKey - The data structure for a composite
@@ -1565,9 +1565,9 @@ B.1.  Generic Composite Public Key Examples
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 28]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 28]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    -----BEGIN PUBLIC KEY-----
@@ -1621,9 +1621,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 29]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 29]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    -----BEGIN PRIVATE KEY-----
@@ -1677,9 +1677,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 30]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 30]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    algorithm: AlgorithmIdentifier{id-composite-key}
@@ -1733,9 +1733,9 @@ B.2.1.  pk-example-ECandRSA
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 31]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 31]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    -----BEGIN PUBLIC KEY-----
@@ -1789,9 +1789,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 32]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 32]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    -----BEGIN PRIVATE KEY-----
@@ -1845,9 +1845,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 33]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 33]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    algorithm: AlgorithmIdentifier{id-pk-example-ECandRSA}
@@ -1901,9 +1901,9 @@ B.2.2.  id-Dilithium3-ECDSA-P256
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 34]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 34]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 -----BEGIN PUBLIC KEY-----
@@ -1957,9 +1957,9 @@ Srzd4w0i+5dCNM9rX
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 35]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 35]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    algorithm: AlgorithmIdentifier{id-Dilithium3-ECDSA-P256}
@@ -2013,9 +2013,9 @@ RWBAFBWUiAyM4hwIwUkBgFwc0I3QlhGYxECR0QQVUhRIUcjEihgYxiAQyBySBciB2SHQoJRVSdW
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 36]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 36]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 cyUAc1N2hRhQMGBVQwJFeAcVNTA1gEggMxSEUGd4Y3FWSFcnRRAFGEUldChUcwWEFnEigVZnZTB
@@ -2069,9 +2069,9 @@ XnyDiUwdxO/i0onKxh56aI9sPUptY8AGOArV/1DZ5gJqjcF9BMs1CTZTGQiReyL/stfgkDcUvbb
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 37]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 37]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 a3+K8beH93CNe2fYYOPIVc02fY9kD85HW1ljtsm6caRAHZl0IxXWpeGbmutqhuWyWe6uVpP21rt
@@ -2125,9 +2125,9 @@ B.2.3.  id-Dilithium3-RSA
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 38]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 38]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    id-dilithium3_aes 1.3.6.1.4.1.2.267.11.6.5
@@ -2181,9 +2181,9 @@ dN2ayilmvdG06dMwrGKs2Tag5HKbUSMPA3BlKvvqrJhMb3w86xPf2MnvWzVWmi0tpE2zcCgXkX+
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 39]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 39]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    which decodes as:
@@ -2237,9 +2237,9 @@ MEdERGZIdSADhIJQdDNHcVVxiHNjUVQwUUAXKHFxWDOIVzQQBQN2iFQUECQEgGGGh2dRKARQaCY
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 40]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 40]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 RhUjRHgSEygXQkAXUHaDA4JCNYYlUVF1GHNAiFQDQyQINCNzISI1cichgTYVJTdEAISCExFhEYU
@@ -2293,9 +2293,9 @@ T5IeA95LI0GP2sv3a9ZX4JUKFq+pAB5t7EwcGj9/htQ1MOKItwAGgYJvTVKmiCgO48UxqinqH+j
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 41]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 41]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 qyDKcXNC9cqw4SVVOa9ulu7O0EgARObu0mxA1PMvJZ8VPaARQl/vVejgnLUUqoqD0zaZprt8wQY
@@ -2349,9 +2349,9 @@ oxUvT9LYWtcF4aPdA7GqgwKAybHq0UYzc2Uggki4gKtlw9MHdzz0u1jnu42sJ7qjadVlWH/UwpV
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 42]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 42]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 uK5jmzcHmWFbzrFP2O6p0Jpq0AP/EcNKjbD0pxUuGF5RbbIuTQeXfG3z5pkhAoGBAO7qVBwUZCg
@@ -2405,9 +2405,9 @@ HymrF59in1pXEPnEWLZ9xLO5A6cg==
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 43]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 43]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    which decodes as:
@@ -2461,9 +2461,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 44]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 44]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 -----BEGIN PRIVATE KEY-----
@@ -2517,9 +2517,9 @@ B.2.5.  id-Falcon512-Ed25519
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 45]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 45]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 B.2.6.  id-SPHINCSsha256256frobust-ECDSA-P256
@@ -2573,9 +2573,9 @@ Eytrtq3H7e59JYdkceK1h+T8jZFyUP5e0M=
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 46]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 46]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 -----BEGIN PRIVATE KEY-----
@@ -2629,9 +2629,9 @@ OPsmcKlPF3LxUxakZfULqtmblGwqztrw0753HBrxqjhk008OsDyLMygMJ8f98bfQOiguYLgLInc
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 47]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 47]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 hO/cJzUoK/RJopPl3vxtxsJzv3CZxchX2NgR6UJ6faQRi85ksW5dDt3yl9eqfl24NXbnbd1Yj5W
@@ -2685,9 +2685,9 @@ hY38bbUDRZ+rMSGAntqdIIoiVTXThCegPJrT6aol/EB6thiYVPoW9ny6Gu6HoVDVBQLNgK10fpG
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 48]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 48]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 qg66a/l2U9chpvZZMBMfAEWw+QRLvjrFphFwm3epRLPUZSQOZ30/xnnArZ42bvPrxHdvDQvKtuF
@@ -2741,9 +2741,9 @@ GOU1gCuPuJpLhgwgZswEAYHKoZIzj0CAQYFK4EEACMDgYYABACe7fcRLUKh2ESJPrFIHMHXIkRf
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 49]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 49]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 -----BEGIN PRIVATE KEY-----
@@ -2797,9 +2797,9 @@ HVRn05VvST60BVcrDXgLgdY49STnebgJJES6cW2b0/hyNJh0/QeVWQE5xJoh6+D7JNj5p51vahQ
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 50]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 50]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 4gsEI0KppuThC+HJ/nWyerpB0PQh184dkIn/SdwAR2sJGqznDLUfYv7ynU+bgYwId9AKdEvp1pJ
@@ -2853,9 +2853,9 @@ ayNbo1DbmDDLYnX7ts2sG+tC64hWNsMQQZ9oqXA1++VLC5RES4NxJeXDRRCUE7rR37XD6WJWa8b
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 51]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 51]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 nzEix46lSIT2YtRwVqKsEIzpjHs1BuwoMOAsVa15iLi/rx7Cxw2r4RcAH9NviaKhS2elGu4cr9D
@@ -2909,9 +2909,9 @@ ATpgiF8HBh+EAPBF/3Ok94IfBCAAPDH/3/g1wABg0XQCi6MIQ/+IIee/s4Q/ET/SgEIHeA6IAg9
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 52]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 52]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 /0P//7vwAAEQYR9ELgie58vxi90Gwb6D4Pj5/oRfB4PyCCEAPB+QIBj/8PSf4L/g/H7ZA/6M3ff
@@ -2965,9 +2965,9 @@ CoICLyYSjpsUIb0x80OmDyZQ53NHiJyNtPtl2+NgtSQj7mL0nwCC5rkRBW5YCWHrwyIBMOnYvy3
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 53]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 53]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 PWUhe8JFE8gzdhEbJndS3UY9avdlZKRphaBETz13Q7/XBigIYvCbom5arWsJL62EnSV8+bGXZmG
@@ -3021,9 +3021,9 @@ p/+chFXAfT43X85TfaKEbI2FjfBXkSXKRDM4RdzHwlSsSC/gNA7Uy7phndqxrLI+18wOVXtwXT4
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 54]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 54]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 11Rk/RIBXw1HddPk7wXYi8UQ2DGMdg3zNdDk9C4H0OvLttX+X9jynJAcoB5ioTb/Y7KNMftUVLs
@@ -3077,9 +3077,9 @@ Kt9eqDOKJRYrn0OdLLBxWc17npXzYZTRJZU+uOjWL8qqQCzDWdmLGWEoIiIpF1TavaAZ2XGkkgl
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 55]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 55]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 ViudaYgqiRxpXazbpxojNofBV8YoycOXRgelhMKgnFqS9vlaFzacyRHSAUB62CpiAGWUZIir6Jm
@@ -3133,9 +3133,9 @@ iKAw5IRVQWXCEX3g8x4UbQb9L0gq1MnqxVsn5g5MjpG8MCAwEAAQ==
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 56]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 56]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    algorithm: AlgorithmIdentifier{id-Dilithium5-Falcon1024-ECDSA-P521}
@@ -3189,9 +3189,9 @@ i3Coi0YBkUCxWTYECyAJEAEIE6SBFAjRmQCpYXUGJFcIgpSuCUZFEAbM2RcAG4RAlCUSGwSl4HC
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 57]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 57]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 uG3TsggZgAVUSCbbIDIExZBAIgJYGCrLuCUaQowaNYYYNjJZsmmjtCwjsoULIArRREpKmCwQGSX
@@ -3245,9 +3245,9 @@ ddda/Yi9I+MNsm819K/hw4cfV3XgwxLErncWRlON7MCYT4G9RyaqrizhOZHysoAfvLHwlC62OTK
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 58]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 58]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 b2fg8y8C1Ab9Tx0B4FDGyo/0rNtsI6X/tXpNb8ddCPy0OSrMHoW36H9sPk5o2aLezKd5iDVfkxJ
@@ -3301,9 +3301,9 @@ U6gNoKSL1zcY/fDK8jH/lLXRjbNAW8zuxrRQpaGaYQePfCfVFOPS5uWdX6o0F3RQbTta3o7lMiA
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 59]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 59]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 ytwVpyMB+ubHk+h8HhgaOpVCIXR0NIC6tbIMkFj/HlnM7qA7AqBcmjq+pGKYpxFKiAMR6H/Am2l
@@ -3357,9 +3357,9 @@ tv7K/gKFf3k8czbE+bbAQAk8gr1GObF9SUR+fUS9fQH9f8A+/0S6gcg/Bfn3Qz53BIJGBQKDv7r
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 60]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 60]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 /ekM8OQAG9sH0iLy0vcF9wv/3v32A/EO6OEU8AXjBQDlLPPxDQ8UIPAjFR7dI9Qw5w/zEyAFH8b
@@ -3413,9 +3413,9 @@ DANBgkqhkiG9w0BAQEFAASCBugwggbkAgEAAoIBgQCc8x0qq2jSuQhAVnTBLJpeYHeUa/x4tZlL
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 61]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 61]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
 UhbTziOADVcmHwJaupEXAzViCqoQ0Nk44ZmR9sdDPatz/Pil55Ssrv6NAEtGHV5HWkdU0AxAtcU
@@ -3469,9 +3469,9 @@ Appendix C.  ASN.1 Module
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 62]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 62]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    <CODE STARTS>
@@ -3525,9 +3525,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 63]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 63]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    --  &paramPresence - parameter presence requirement
@@ -3581,9 +3581,9 @@ Internet-Draft              PQ Composite Keys               October 2022
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 64]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 64]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
        PARAMS ARE absent
@@ -3637,9 +3637,9 @@ Appendix E.  Contributors and Acknowledgements
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 65]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 65]
 
-Internet-Draft              PQ Composite Keys               October 2022
+Internet-Draft              PQ Composite Keys              November 2022
 
 
    John Gray (Entrust), Serge Mister (Entrust), Scott Fluhrer (Cisco
@@ -3693,4 +3693,4 @@ Authors' Addresses
 
 
 
-Ounsworth, et al.         Expires 25 April 2023                [Page 66]
+Ounsworth, et al.          Expires 12 May 2023                 [Page 66]


### PR DESCRIPTION
For composite keys, component ordering is determined by the definition of the associated composite algorithm identifier.  The prior wording was ambiguous given the possibilities that a given composite key structure may be associated with an explicit composite algorithm identifier, the generic composite algorithm idenfitier, or no composite algorithm identifier.